### PR TITLE
Big update.

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,3 +212,4 @@ or send a PR to [our github repo](https://github.com/gnulag/gnulag.net)
 
 ---
 © 2021 browndawg et al
+

--- a/README.md
+++ b/README.md
@@ -139,14 +139,17 @@ sudo edge -d n2n0 -c gnulag \
 ```
 
 ### Minecraft
+
 Minecraft on `gnulag.net:25565`.
 
 ### Xonotic
+
 To connect to the xonotic server get [xonotic](http://xonotic.org/), start it,  
 open the console with `~` and type `connect cocaine.farm:26000`.  
 You will need to reconnect on map change
 
 ## GNULag
+
 ![](./img/de7a5ea1a6.png)
 
 ## Regulars
@@ -181,6 +184,7 @@ You will need to reconnect on map change
 * **basso**: his servers are more _bronken_ than audron's (emanating smoke signals so owner knows what's up). Great memeposter, **belzurix** has stashed many good ones of those memes.
 * **WnB**: has great knowledge but prefers getting erect. Posts fap materials constantly. Biggest ~~dick~~ duck hunter in the history of **#gnulag**
 * **iamidly**: has weird ideas about how computers should be (most of those are shared with **belzurix**). Runs his own distro and dogfoods his own coreutils-replacement. Doesn't tolerate colorful output.
+
 ## Regulars Emeritus :(
 
 * **Crocodillian**: Resident weed smoker. Is into good music. Codes C (allegedly). Also has a history of Perl programming (which he regrets). Owns 420 core workstation that everyone's jealous of.

--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ GNU/Lag doesn't have many rules you'd have to explicitly state. Don't be a dick,
 
 * No CP (we'll report you to every three letter agency in existence).
 * **NSFW** content need not be marked. Please mark gore and such as **NSFL**.
-* No lurking - you should spend time in channel regularly. In practice, this means that if you're 24/7 logged in, then at least every two weeks, you have to do some non-fake activity. This is to avoid people making local logs without adding anything to the channel. Compare and contrast [m]atrix lurker policy.
+* No lurking [^1]
 * Don't post logs anywhere.
 * Don't sneeze whilst getting fingered.
 
 ## Links
 
 * [Webchat](https://tknk.io/A5YW)
-* [Stats](https://gnulag.stats.c8h10n4o2.xyz/)
+* ~~[Stats](https://gnulag.stats.c8h10n4o2.xyz/)~~
 * [Reddit](https://old.reddit.com/r/gnulag)
 * [GitHub](https://github.com/gnulag)
 * [Link](https://d3ieicw58ybon5.cloudfront.net/ex/350.350/shop/product/d16f82bc07374717bfece1cdba56d8b8.jpg)
@@ -31,17 +31,20 @@ While the channel was mostly founded by members of another **Linux** channel, **
 * Drugs.
 * Kill all Humans.
 * Indians being indians and hungarians being hungarians
+* How awesome canada is
 * Computer Science and Programming.
 * Zygohistomorphic prepromorphisms.
 * Poor career decisions (ask **whiteph** or **belzurix**).
 * Bad Dragons (actually, dildos of all shapes and sizes).
 * Definitions of controversial words.
 * Religion, and the occult.
-* Life size Lennart Poettering cutouts with a hole where the mouth is supposed to be.
+* Life size Lennart Pöttering cutouts with a hole where the mouth is supposed to be.
 * LGBTQIA+ stuff, porn, and sexuality in general.
 * The existential threat of frontend web development.
 * The UNIX philosophy and ~~how modern development is taking a giant shit on it~~ how good Lennart looks in plaid.
 * Definitely not talking about inline skating.
+* Emacs and how awesome it is
+* regular CLI vs TUI vs GUI pancrase fights
 
 ## FAQ
 
@@ -73,10 +76,10 @@ https://snoonet.org/anope#NickServ.
 ### How do I stay permanently connected to the channel?
 
 * `/mode +j #gnulag`, or google on how to set up `autojoin` in your IRC client.
-* Get a [Snoonet BNC](https://snoonet.org/bnc) account (if you don't already have one),  
-  or set up a [Quassel Core](https://quassel-irc.org/) / [ZNC server](https://wiki.znc.in/ZNC) somewhere.
+* Get a [Snoonet BNC](https://snoonet.org/bnc) account (if you don't already have one), if you've been to Snoonet for more than a month
+* set up a [Quassel Core](https://quassel-irc.org/) / [ZNC server](https://wiki.znc.in/ZNC) somewhere.
 * Alternatively, ping **crystalmett**, **browndawg**, or **skg** for an account on their server.
-* If you've been to Snoonet for more than a month, they have their own bouncer.
+
 
 ### Can I ask for programming / unix help?
 
@@ -84,12 +87,13 @@ Yes. We're not an official help channel, but regulars will often help you out wi
 
 ### How do I share images / files / text on IRC?
 
-You'll have to host it somewhere, and share a public link.  
+You'll have to host it somewhere, and share a public link. There are scripts and tools that can automate this for you. Ask on the channel.
+
 We have three services hosted by community members:
 
-* [thecum.zone](https://thecum.zone)
-* [p.gnulag.net](https://p.gnulag.net)
-* [WaifuPaste](https://waifupaste.moe)
+* [thecum.zone](https://thecum.zone)   - by **Volkor**
+* [p.gnulag.net](https://p.gnulag.net) - by **audron**
+* [WaifuPaste](https://waifupaste.moe) - by **skg**
 
 or use public services like:
 
@@ -104,9 +108,7 @@ Please note that DCC is disabled on Snoonet.
 
 For code or any arbitrary text really [github gist](https://gist.github.com/) is a good choice.
 
-There are scripts and tools that can automate this for you. Ask on the channel.
-
-Don't be surprised if nobody wants to open a .tar.xz file of yours. [Read more on zip bombs](https://en.wikipedia.org/wiki/Zip_bomb).
+Note by **belzurix**: Don't be surprised if nobody wants to open a .tar.xz file of yours. [Read more on zip bombs](https://en.wikipedia.org/wiki/Zip_bomb).
 
 ## History
 
@@ -115,13 +117,13 @@ Don't be surprised if nobody wants to open a .tar.xz file of yours. [Read more o
 No. Its #lmr with porn, commies and non-whites, ~~minus the [m]atrix lurkers.~~ (PURGED)  
 **Not affiliated with the subreddit / channel.**, many regulars show up in both chanels, though. This created border conflicts which later escalated into a full-scale war. #gnulag won the war without losing a single battle.
 
-### How is this related to #redoxmasterrace ?
+### How is the channel related to #redoxmasterrace ?
 
-We're temporarely allied with them against the vile necromancers who are trying to make an army from the rotting corpse that #linuxmasterrace is.
+We were temporarely allied with them against the vile necromancers who are trying to make an army from the rotting corpse that #linuxmasterrace is.
 
 ### What is #69
 
-It is a channel funded by our government. It's manufactured opposition, a honeypot for dissidents.
+It was a channel funded by our government. It's manufactured opposition, a honeypot for dissidents. **k33k** was responsible for managing it.
 
 ## Bots & Games
 
@@ -151,11 +153,8 @@ You will need to reconnect on map change
 
 * **browndawg**: BTW he uses Arch Linux. Benevolent, fair OP. Has the power of JS rockstars AND normal rockstars. Vim ninja. ~~Sometimes~~ Always shits on streets. ~~Wants to sex the benis.~~  
   Is as straight as he is white, and he's white AF.(LIES (allegedly)).
-* **ix**: Resident weeb and audiophile, doesn't like any guitar that isn't a telecaster.  
-  Patron of the occult. Not to be bullied.
-* **xi**: Author of our bot (vini). In a toxic relationship with baguettes. FreeBSD shill. Fuchsia shill. Writes segfaults in C that only compile on **FreeBSD** UPDATE: has committed the NodeJS heresy. Now his bot, jesi, works on linux, too.
+* **xi**: Author of our bot (vini). In a toxic relationship with baguettes. FreeBSD shill. Fuchsia shill. Writes segfaults in C that only compile on **FreeBSD** UPDATE: has committed the NodeJS heresy. Now his bot, **jesi**, works on linux, too.
 * **Zowlyfon**: Resident chad, lifts. Haskell Shill. In a sexual relationship with his headphones.
-* **whiteph**: Plays Guitar. Really good at physics.
 * **RadiantBastard**: His job is to remove kebab and add chaos. Uses macOS like a fuccboi. Resident memeposter. Bringer of all news.
 * **AndroidKitKat/skg**:ウィーブ, Pretends to understand Japanese, actually kinda understands japanese, wants to live in japan someday, dont fuck with my bio you morons, Resident weeb and connoisseur of all anime. Other resident fuccboi (seriously, MacOS bad). Possibly owns anal beads, freeballs it every once in a while, wants the longest bio to assert dominance over the other virgin bios, would also occasionally not turn down the notion of being a cute anime girl
 * **pta2002**: Idiot kid. Actually a genius. Plays plastic guitar, ~~but would love to play actual guitar~~ **UPDATE**: plays actual guitar too. Likes BSPWM, Fedora, and allegedly codes in Go in his spare time, only to complain about it afterwards. Has a crush on Link, ~~no~~ ~~full~~ half homo.
@@ -169,34 +168,43 @@ You will need to reconnect on map change
 * **TinyTimmyTokyo**: Resident gayboye, Gantoo Lunix nerd, and eternally sleepless lurker. (Allegedly) is somewhat good at coding in C++ and Shell. Has Golden Retriever doggo but likes cats (don't ask why). Chaotic evil regexer. Also resident furry. Into transformation porn.
 * **za**: Depressed Arch Linux boye, is weirdly into keyboards, and anime tiddies. He pretends to be an audiophile, and vapes.
 * **justJanne**: Genius. Never forgets a thing she reads. Resident data collection agency.
+* **Seirdy**: big fan of CLIs and prefers everything to GUI. His data collection is greedier than Zuckbook's, Twatter's and NSA's combined.
 * **crystalmett**: Turn-ons: OPSEC Turn-offs: [TRIPLE REDACTED AND BURNED FOR GOOD MEASURE]
-* **belzurix**: Comrade general. Has the irc equivalent of nuclear weapons. 𓂸 Resident changeling. **☭** sleeper cell. Wishes to establish GNUSSR. Suffers when something costs >0.001$.
+* **belzurix**[^3]: Comrade general. Fell into the Emacs rabbit hole. Help him so he can leave it!
 * **Rolfe**: Farm fresh Idaho potato. Waifu supplier. Insists her stuffed toy collection doesn't come alive when you're asleep. Dabbles in rule34 involving extra long moustaches.
 * **random-nick**: Impossible to annoy, resident Common Lisp shill. Rekts any other lisp dialect that appears in the dicussion.
 * **Romanson**: Not roman, but son. Somewhere in a shitty 3rd world cuntry. Been bitching about not having a bio while being a bio student. The absolute botman.
 * **lanosz**: Resident slavic slavaboo (cringe), actually the only sane person in the entire channel (source: lanosz). Bash scripting leviathan. Catbottom wont stop obsessing over him. Speaks proper interslavic but is generally too dumb for most stuff.
 * **IndyJoenz** Came back recently. Doing l33t h4x and ascii arts. Mascot of the channel, representing its spirit. Has DukeTogo as a bot.
 * **d1pl0mat**: He often disappears for months on end with no explanation; this is normal. Currently a Manjaro user because Arch is overrated. ~~Is trying to popularize the `.gvy` file extension because `.groovy` is irritatingly long.~~ Has _officially_ added `.gvy` as a recognized mimetype on most Unix-based desktops.
-
+* **k33k**: master hacker and shitposter with an ego bigger than your mum. In combat, pommels opponents into the ground.
+* **basso**: his servers are more _bronken_ than audron's (emanating smoke signals so owner knows what's up). Great memeposter, **belzurix** has stashed many good ones of those memes.
+* **WnB**: has great knowledge but prefers getting erect. Posts fap materials constantly. Biggest ~~dick~~ duck hunter in the history of **#gnulag**
+* **iamidly**: has weird ideas about how computers should be (most of those are shared with **belzurix**). Runs his own distro and dogfoods his own coreutils-replacement. Doesn't tolerate colorful output.
 ## Regulars Emeritus :(
 
 * **Crocodillian**: Resident weed smoker. Is into good music. Codes C (allegedly). Also has a history of Perl programming (which he regrets). Owns 420 core workstation that everyone's jealous of.
 * **Jennifer-Lawrence**: Actually a black man from rural Alabama. Would like to be an anime girl.  
   Has 10 terabytes of encrypted hentai on his university's Google Drive. Only actually appeared to fucc ducks and bang dicks.
 * **cheers**: Accelerationist. Responsible for global warming. Defected to #redoxmasterrace **> giving in to memes**
-* **theluke**: Member[^1] of the suprisingly large wog population on gnulag. Claims his brane is too small to learn anything other than vim. Edgy af.
+* **theluke**: Member[^2] of the suprisingly large wog population on gnulag. Claims his brane is too small to learn anything other than vim. Edgy af.
 * **Tuxiee**: † [In Memoriam](https://gnulag.net/tuxiee-in-remembrance.html)
+* **ix**: Resident weeb and audiophile, doesn't like any guitar that isn't a telecaster.  
+  Patron of the occult. Not to be bullied.
+* **whiteph**: Plays Guitar. Really good at physics.
 
 ## Bots
-* **DukeTogo**: Best not to talk to it. If provoked, it will BTFO you in microseconds. Says **AndroitKitKat** is gay and seems not to know about **browndawg**.
+* **DukeTogo**: Best not to talk to it. If provoked, it will BTFO you in microseconds. Says **AndroitKitKat** (now skg) is gay and seems not to know about **browndawg**.
 * **gonzobot**: Snoonet's cloudbot instance. All of its functions that rely on external APIs are broken.
-* **CYBERDUNCE**: AI-core re-enabled. Shitposts constantly. Regulars bullied it to oblivion, resulting in constant e-depression.
-
+* **CYBERDUNCE**: ~~AI-core re-enabled. Shitposts constantly.~~ Regulars bullied it to oblivion, resulting in constant e-depression. Bringer of RSS.
+* **jesi**: **xi**'s utter crap NodeJS bot that fucks itself up during every netsplit.
+* **lalilo**: Bot to control the gnulag radio.
 If you're regular, PM **browndawg** or **audron** to get your name and description on here,  
 or send a PR to [our github repo](https://github.com/gnulag/gnulag.net)
 
-[^1]: Dick
+[^1]: You should spend time in channel regularly. In practice, this means that if you're 24/7 logged in, then at least every two weeks, you have to do some non-fake activity. This is to avoid people making local logs without adding anything to the channel. Compare and contrast [m]atrix lurker policy.
+[^2]: Dick
+[^3]: as unix standard dictates
 
 ---
 © 2021 browndawg et al
-


### PR DESCRIPTION
- make the explanation of lurking into a footnote
- stats link is defunct, looks now reflect that
- Topic update:
  - add canada among topics
  - lennart's name is now spelled as it should be
  - emacs shitposting
  - first flamewar entry (plan to expand them)
- make ZNC guide more readable (opinionated)
- Channel relations:
  - change #rmr tense
  - change #lmr tense
  - change #69 tense, add k33k there
- Bios:
  - add bios for Seirdy, basso, WnB, iamidly and k33k
  - change belzurix bio
  - move ix and whiteph to emeritus due to inactivity
  - update DukeTogo, CYBERDUCE
  - add jesi, lalilo